### PR TITLE
Update for prediction

### DIFF
--- a/src/mdof/prediction.py
+++ b/src/mdof/prediction.py
@@ -92,11 +92,11 @@ class Realization:
         realization = mdof.system(method='srim', inputs=inputs, outputs=outpts, **conf)
 
         if stabilize:
-            A_stable, real_mode_indices = stabilize_discrete(A=realization[0], verbose=verbose, list_filtered_modes=True)
+            A_stable, indices = stabilize_discrete(A=realization[0], verbose=verbose, list_filtered_modes=True)
             eigvals = np.linalg.eigvals(realization[0])
             modes_removed = np.array([
-                real_mode_indices,
-                [_get_period_from_discrete_A_eigval(eigvals[i], dti) for i in real_mode_indices]
+                indices,
+                [_get_period_from_discrete_A_eigval(eigvals[i], dti) for i in indices]
             ])
             realization = (A_stable,*realization[1:])
             self._modes_removed = modes_removed

--- a/src/mdof/prediction.py
+++ b/src/mdof/prediction.py
@@ -44,10 +44,9 @@ def _get_error(true, test, metric='l2_norm', normalized=True):
             return error/sum(np.abs(true))
         return error
     if metric == 'are_max_normalized':
-        #error = np.mean(np.abs(test-true)) # average absolute relative error
-        error = np.mean(np.abs(test - true) / (np.abs(true) + 1e-8))
-        # if normalized:
-        #     return error/max(np.abs(true)) # divide by maximum absolute value
+        error = np.mean(np.abs(test-true)) # average absolute relative error
+        if normalized:
+            return error/max(np.abs(true)) # divide by maximum absolute value
         return error
     if metric == 'sym':
         error = sum(test-true)
@@ -94,9 +93,11 @@ class Realization:
 
         if stabilize:
             A_stable, real_mode_indices = stabilize_discrete(A=realization[0], verbose=verbose, list_filtered_modes=True)
-            modes_removed = np.array([real_mode_indices,[
-                _get_period_from_discrete_A_eigval(np.linalg.eig(realization[0])[0][2*i], dti) for i in real_mode_indices
-            ]])
+            eigvals = np.linalg.eigvals(realization[0])
+            modes_removed = np.array([
+                real_mode_indices,
+                [_get_period_from_discrete_A_eigval(eigvals[i], dti) for i in real_mode_indices]
+            ])
             realization = (A_stable,*realization[1:])
             self._modes_removed = modes_removed
         else:

--- a/src/mdof/prediction.py
+++ b/src/mdof/prediction.py
@@ -44,9 +44,10 @@ def _get_error(true, test, metric='l2_norm', normalized=True):
             return error/sum(np.abs(true))
         return error
     if metric == 'are_max_normalized':
-        error = np.mean(np.abs(test-true)) # average absolute relative error
-        if normalized:
-            return error/max(np.abs(true)) # divide by maximum absolute value
+        #error = np.mean(np.abs(test-true)) # average absolute relative error
+        error = np.mean(np.abs(test - true) / (np.abs(true) + 1e-8))
+        # if normalized:
+        #     return error/max(np.abs(true)) # divide by maximum absolute value
         return error
     if metric == 'sym':
         error = sum(test-true)

--- a/src/mdof/validation.py
+++ b/src/mdof/validation.py
@@ -123,7 +123,7 @@ def stabilize_discrete(A, verbose=False, list_filtered_modes=False):
         because magnitude of eigenvalue is greater than 1 ({test_string(test)})
         """)
     if list_filtered_modes:
-        return filtered_A, real_mode_indices
+        return filtered_A, indices
     else:
         return filtered_A
 


### PR DESCRIPTION
I am not sure if this is an issue.There will have an index out of bounds issue in the Realization stabilization step. The previous code incorrectly used 2*i when accessing eigenvalues, which caused errors when the system order was small. The updated code now uses i directly to match the indices returned by stabilize_discrete, ensuring correct mode period mapping. No changes were made to the error calculation formulas.